### PR TITLE
Don't include input values by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ A **simple**, **IDE-friendly**, **fluent** and **extensible** Java validation li
 
 ## Why ValidCheck?
 
-**Simple** - Clean API with intuitive method names  
-**IDE-friendly** - Full autocomplete support and type safety  
-**Fluent** - Method chaining for readable validation code  
-**Extensible** - Easy to add custom validation methods
+- Clean API with intuitive method names
+- Full autocomplete support and type safety
+- Method chaining for readable validation code
+- Easy to add custom validation methods
 
 ```java
 // Simple and readable
@@ -259,9 +259,9 @@ try {
     ValidCheck.require().isPositive(-5, "age");
 } catch (ValidationException e) {
     System.out.println(e.getMessage()); 
-    // "'age' must be positive, but it was -5"
+    // "'age' must be positive"
     
-    List<String> errors = e.getErrors(); // ["'age' must be positive, but it was -5"]
+    List<String> errors = e.getErrors(); // ["'age' must be positive"]
 }
 ```
 
@@ -275,10 +275,10 @@ try {
         .validate();
 } catch (ValidationException e) {
     System.out.println(e.getMessage());
-    // "'username' must not be null; 'age' must be positive, but it was -1"
+    // "'username' must not be null; 'age' must be positive"
     
     List<String> errors = e.getErrors();
-    // ["'username' must not be null", "'age' must be positive, but it was -1"]
+    // ["'username' must not be null", "'age' must be positive"]
 }
 ```
 

--- a/validcheck/src/main/java/io/github/aglibs/validcheck/ValidCheck.java
+++ b/validcheck/src/main/java/io/github/aglibs/validcheck/ValidCheck.java
@@ -23,23 +23,24 @@ public final class ValidCheck {
    * Creates a new batch validator that collects all validation errors before throwing. This allows
    * multiple validation failures to be reported at once.
    *
-   * @return a new {@link BatchValidator} instance configured to include values and fail-fast
+   * @return a new {@link BatchValidator} instance configured to exclude values and fill stack
+   *     traces
    * @see BatchValidator
    */
   public static BatchValidator check() {
-    return new BatchValidator(true, true);
+    return new BatchValidator(false, true);
   }
 
   /**
    * Creates a new validator with fail-fast behavior. Throws a {@link ValidationException}
    * immediately upon the first validation failure.
    *
-   * @return a new {@link Validator} instance configured to include values, fail-fast, and fill
+   * @return a new {@link Validator} instance configured to exclude values, fail-fast, and fill
    *     stack traces
    * @see Validator
    */
   public static Validator require() {
-    return new Validator(true, true, true);
+    return new Validator(false, true, true);
   }
 
   /**

--- a/validcheck/src/main/java/io/github/aglibs/validcheck/Validator.java
+++ b/validcheck/src/main/java/io/github/aglibs/validcheck/Validator.java
@@ -41,12 +41,12 @@ import java.util.regex.Pattern;
  * <pre>{@code
  * public class MyValidator extends Validator {
  *
- *   public static MyValidator strictValidation() {
- *     return new MyValidator(false, true, true); // No values in errors, fail-fast, with stack traces
+ *   public static MyValidator withValues() {
+ *     return new MyValidator(true, true, true); // Include values in errors, fail-fast, with stack traces
  *   }
  *
  *   public static MyValidator lenientValidation() {
- *     return new MyValidator(true, false, false); // Include values, batch errors, no stack traces
+ *     return new MyValidator(false, false, false); // Exclude values, batch errors, no stack traces
  *   }
  *
  *   protected MyValidator(boolean includeValues, boolean failFast, boolean fillStackTrace) {

--- a/validcheck/src/test/java/io/github/aglibs/validcheck/BatchValidatorTest.java
+++ b/validcheck/src/test/java/io/github/aglibs/validcheck/BatchValidatorTest.java
@@ -31,7 +31,7 @@ class BatchValidatorTest {
         .containsExactlyInAnyOrder(
             "'name' must not be null",
             "'email' must not be null or empty",
-            "'age' must be positive, but it was -5");
+            "'age' must be positive");
 
     // Then - Test isValid() method
     assertThat(validator.isValid()).isFalse();
@@ -40,7 +40,7 @@ class BatchValidatorTest {
     assertThatThrownBy(validator::validate)
         .isInstanceOf(ValidationException.class)
         .hasMessageContaining(
-            "'name' must not be null; 'email' must not be null or empty; 'age' must be positive, but it was -5");
+            "'name' must not be null; 'email' must not be null or empty; 'age' must be positive");
 
     // Given - Valid data
     BatchValidator validValidator =
@@ -65,25 +65,32 @@ class BatchValidatorTest {
     BatchValidator combinedValidator =
         ValidCheck.check()
             .notEmpty("", "email") // Add one more error
+            .isNull("")
+            .isNull("", "a")
+            .isNull("", () -> "b")
+            .isNull(null, "ok")
             .include(userValidator)
             .include(addressValidator);
 
     // Then - Should have combined all errors from all validators
-    assertThat(combinedValidator.getErrors()).hasSize(5);
+    assertThat(combinedValidator.getErrors()).hasSize(8);
     assertThat(combinedValidator.getErrors())
         .containsExactlyInAnyOrder(
+            "parameter must be null",
+            "'a' must be null",
+            "b",
             "'email' must not be null or empty",
             "'username' must not be null",
-            "'password' must have length between 5 and 20, but it was 'ab'",
+            "'password' must have length between 5 and 20",
             "'street' must not be blank",
-            "'zipCode' must be positive, but it was -1");
+            "'zipCode' must be positive");
 
     // When - Include validator with no errors
     BatchValidator emptyValidator = ValidCheck.check();
     combinedValidator.include(emptyValidator);
 
     // Then - Should not change error count
-    assertThat(combinedValidator.getErrors()).hasSize(5);
+    assertThat(combinedValidator.getErrors()).hasSize(8);
   }
 
   @Test
@@ -261,22 +268,22 @@ class BatchValidatorTest {
         .hasSize(17)
         .containsOnly(
             "parameter must not be null",
-            "parameter must be between 1 and 50, but it was 100",
+            "parameter must be between 1 and 50",
             "parameter must not be null or empty",
             "parameter must not be null or empty",
             "parameter must not be null or empty",
             "parameter must not be blank",
-            "parameter must have length between 1 and 100, but it was 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...'",
-            "parameter must have size between 2 and 5, but it was [a]",
-            "parameter must have size between 2 and 5, but it was {}",
-            "parameter must be positive, but it was -5",
-            "parameter must be negative, but it was 5",
-            "parameter must match pattern '^[a-z]+$', but it was 'ABC123'",
-            "parameter must match pattern '^[a-z]+$', but it was 'ABC123'",
-            "parameter must be non-negative, but it was -5",
-            "parameter must be non-positive, but it was 5",
-            "parameter must be at least 0, but it was -5",
-            "parameter must be at most 50, but it was 100");
+            "parameter must have length between 1 and 100",
+            "parameter must have size between 2 and 5",
+            "parameter must have size between 2 and 5",
+            "parameter must be positive",
+            "parameter must be negative",
+            "parameter must match pattern '^[a-z]+$'",
+            "parameter must match pattern '^[a-z]+$'",
+            "parameter must be non-negative",
+            "parameter must be non-positive",
+            "parameter must be at least 0",
+            "parameter must be at most 50");
     assertThat(validator.isValid()).isFalse();
 
     // When & Then - Validate should throw with all collected errors


### PR DESCRIPTION
By default don't include input values into the error message. Allow users to opt-in to this