### PR TITLE
Remove tight coupling of exception type from validation

### DIFF
--- a/validcheck/src/main/java/io/github/aglibs/validcheck/BatchValidator.java
+++ b/validcheck/src/main/java/io/github/aglibs/validcheck/BatchValidator.java
@@ -3,6 +3,7 @@ package io.github.aglibs.validcheck;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -69,10 +70,11 @@ public class BatchValidator extends Validator {
    * Constructs a new BatchValidator with the specified configuration.
    *
    * @param includeValues whether to include actual values in error messages for debugging
-   * @param fillStackTrace whether to fill stack traces in thrown exceptions
+   * @param exceptionFactory factory that creates the desired validation exception.
    */
-  protected BatchValidator(boolean includeValues, boolean fillStackTrace) {
-    super(includeValues, false, fillStackTrace);
+  protected BatchValidator(
+      boolean includeValues, BiFunction<String, List<String>, RuntimeException> exceptionFactory) {
+    super(includeValues, false, exceptionFactory);
   }
 
   /**

--- a/validcheck/src/main/java/io/github/aglibs/validcheck/BatchValidator.java
+++ b/validcheck/src/main/java/io/github/aglibs/validcheck/BatchValidator.java
@@ -125,16 +125,6 @@ public class BatchValidator extends Validator {
     return errors.isEmpty();
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * <p>Validates that no errors have been collected and throws an exception if any exist.
-   */
-  @Override
-  public void validate() {
-    super.validate();
-  }
-
   @Override
   public BatchValidator assertTrue(boolean condition, String message) {
     return (BatchValidator) super.assertTrue(condition, message);

--- a/validcheck/src/main/java/io/github/aglibs/validcheck/ValidCheck.java
+++ b/validcheck/src/main/java/io/github/aglibs/validcheck/ValidCheck.java
@@ -1,5 +1,8 @@
 package io.github.aglibs.validcheck;
 
+import java.util.List;
+import java.util.function.BiFunction;
+
 /**
  * Main entry point for the ValidCheck validation library. Provides static factory methods to create
  * validators for parameter validation.
@@ -26,20 +29,53 @@ public final class ValidCheck {
    * @return a new {@link BatchValidator} instance configured to include values and fail-fast
    * @see BatchValidator
    */
+  public static BatchValidator collect() {
+    return collect((message, errors) -> new IllegalArgumentException(String.join(", ", errors)));
+  }
+
+  /**
+   * Creates a new batch validator that collects all validation errors before throwing. This allows
+   * multiple validation failures to be reported at once.
+   *
+   * @param exceptionFactory factory that creates the desired validation exception.
+   * @return a new {@link BatchValidator} instance configured to include values and fail-fast
+   * @see BatchValidator
+   */
+  public static BatchValidator collect(BiFunction<String, List<String>, RuntimeException> exceptionFactory) {
+      return new BatchValidator(true, exceptionFactory);
+  }
+
+  @Deprecated
   public static BatchValidator check() {
-    return new BatchValidator(true, true);
+    return collect(ValidationException::new);
   }
 
   /**
    * Creates a new validator with fail-fast behavior. Throws a {@link ValidationException}
    * immediately upon the first validation failure.
    *
-   * @return a new {@link Validator} instance configured to include values, fail-fast, and fill
-   *     stack traces
+   * @return a new {@link Validator} instance configured to include values, fail-fast
    * @see Validator
    */
+  public static Validator failFast() {
+    return failFast((message, errors) -> new IllegalArgumentException(String.join(", ", errors)));
+  }
+
+  /**
+   * Creates a new validator with fail-fast behavior. Throws a {@link ValidationException}
+   * immediately upon the first validation failure.
+   *
+   * @param exceptionFactory factory that creates the desired validation exception.
+   * @return a new {@link Validator} instance configured to include values, fail-fast
+   * @see Validator
+   */
+  public static Validator failFast(BiFunction<String, List<String>, RuntimeException> exceptionFactory) {
+      return new Validator(true, true, exceptionFactory);
+  }
+
+  @Deprecated
   public static Validator require() {
-    return new Validator(true, true, true);
+    return failFast(ValidationException::new);
   }
 
   /**

--- a/validcheck/src/main/java/io/github/aglibs/validcheck/Validator.java
+++ b/validcheck/src/main/java/io/github/aglibs/validcheck/Validator.java
@@ -127,7 +127,7 @@ public class Validator {
   }
 
   /** Throws ValidationException if any errors have been collected. */
-  protected void validate() {
+  public void validate() {
     if (!errors.isEmpty()) {
       final var errorMessage = String.join("; ", errors);
       throw exceptionFactory.apply(errorMessage, errors);

--- a/validcheck/src/main/java/io/github/aglibs/validcheck/Validator.java
+++ b/validcheck/src/main/java/io/github/aglibs/validcheck/Validator.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
@@ -77,23 +79,25 @@ public class Validator {
   /** Whether to throw immediately on first validation failure. */
   protected final boolean failFast;
 
-  /** Whether to fill stack traces in thrown exceptions. */
-  protected final boolean fillStackTrace;
-
   /** List of collected validation errors. */
   protected final List<String> errors;
+
+  private final BiFunction<String, List<String>, RuntimeException> exceptionFactory;
 
   /**
    * Constructs a new Validator with the specified configuration.
    *
    * @param includeValues whether to include actual values in error messages for debugging
    * @param failFast whether to throw immediately on first validation failure or collect all errors
-   * @param fillStackTrace whether to fill stack traces in thrown exceptions
+   * @param exceptionFactory factory that creates the desired validation exception.
    */
-  protected Validator(boolean includeValues, boolean failFast, boolean fillStackTrace) {
+  protected Validator(
+      boolean includeValues,
+      boolean failFast,
+      BiFunction<String, List<String>, RuntimeException> exceptionFactory) {
     this.includeValues = includeValues;
     this.failFast = failFast;
-    this.fillStackTrace = fillStackTrace;
+    this.exceptionFactory = Objects.requireNonNull(exceptionFactory);
 
     errors = new ArrayList<>();
   }
@@ -126,7 +130,7 @@ public class Validator {
   protected void validate() {
     if (!errors.isEmpty()) {
       final var errorMessage = String.join("; ", errors);
-      throw ValidationException.create(fillStackTrace, errorMessage, errors);
+      throw exceptionFactory.apply(errorMessage, errors);
     }
   }
 

--- a/validcheck/src/test/java/io/github/aglibs/validcheck/ValidatorTest.java
+++ b/validcheck/src/test/java/io/github/aglibs/validcheck/ValidatorTest.java
@@ -1102,7 +1102,8 @@ class ValidatorTest {
   @Test
   void edgeCaseCoverageForMissedBranches() {
     // Test formatMessage with includeValue=false (covers missed branch in formatMessage)
-    Validator validatorNoValues = new Validator(false, true, true); // includeValues = false
+    Validator validatorNoValues =
+        new Validator(false, true, ValidationException::new); // includeValues = false
     assertThatThrownBy(() -> validatorNoValues.notNull(null, "test"))
         .hasMessage("'test' must not be null"); // Should not include value
 


### PR DESCRIPTION
This PR removes the tight coupling of ValidationException from the ValidCheck API. It lets the user specify a factory object (lambda) that is used to create the exception instance when the validation fails in an error.

It also improves the naming of the factory methods in the ValidCheck class to more accurately reflect the functionality of the resulting validators and removes an inconsistency in the validation call pattern.